### PR TITLE
fix: add react plugin for vite and vercel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/node": "^20.3.1",
     "typescript": "^5.2.2",
     "vite": "^4.4.9",
+    "@vitejs/plugin-react": "^4.1.0",
     "tailwindcss": "^3.3.3",
     "postcss": "^8.4.31",
     "autoprefixer": "^10.4.16"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
## Summary
- add `@vitejs/plugin-react` dev dependency required by Vite config
- configure Vercel build to run `npm run build` and serve `dist`

## Testing
- `npm test`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ba0e9e320c83228a0fec8df9905afa