### PR TITLE
fix: register custom colors for Tailwind build

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,7 +2,23 @@ module.exports = {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {
-      colors: {}
+      colors: {
+        ivory: '#FFFFF0',
+        navy00: '#04050f',
+        navy10: '#0B1020',
+        psychedelicPink: '#f6a6c1',
+        psychedelicPurple: '#9b5de5',
+        psychedelicTeal: '#00f5d4',
+        noonBlue: '#7ec8e3',
+        sunsetCrimson: '#e63946',
+        sunsetOrange: '#ff8c42',
+        dawnLavender: '#b8a1ff',
+        dawnRose: '#ffc0cb',
+        highlightIvory: '#fffae5',
+        gridLine: 'rgba(255, 255, 240, 0.2)',
+        textPrimary: '#F1F5F9',
+        textMuted: '#B6C2CF'
+      }
     }
   },
   plugins: []


### PR DESCRIPTION
## Summary
- extend Tailwind config with custom color palette

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68baa1a0dc248322b3febb859e6f04d3