### PR TITLE
Add moon arc path with clipping, color, and direction markers

### DIFF
--- a/src/components/MoonDisc.tsx
+++ b/src/components/MoonDisc.tsx
@@ -4,23 +4,55 @@ import { colors } from '../constants/colors';
 interface Props {
   visible: boolean;
   phase: number; // 0..1
-  altitude: number; // radians
+  x: number;
+  y: number;
+  diameter: number;
+  color: string;
+  altDeg: number;
+  horizonY: number;
+  clipDeg: number;
 }
 
-const MoonDisc: React.FC<Props> = ({ visible, phase, altitude }) => {
+const MoonDisc: React.FC<Props> = ({
+  visible,
+  phase,
+  x,
+  y,
+  diameter,
+  color,
+  altDeg,
+  horizonY,
+  clipDeg,
+}) => {
   if (!visible) return null;
+
   const lit = phase <= 0.5 ? phase * 2 : (1 - phase) * 2;
   const dir = phase <= 0.5 ? 'to left' : 'to right';
-  const gradient = `linear-gradient(${dir}, ${colors.ivory} ${lit * 100}%, ${colors.navy10} ${lit * 100}%)`;
-  const size = 64; // px
-  const canvasHeight = 192; // must match NowPanel canvas height
-  const top = ((Math.PI / 2 - altitude) / (Math.PI / 2)) * (canvasHeight - size);
+  const gradient = `linear-gradient(${dir}, ${color} ${lit * 100}%, ${colors.navy10} ${lit * 100}%)`;
+
+  const top = y - diameter / 2;
+  const left = x - diameter / 2;
+
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    width: `${diameter}px`,
+    height: `${diameter}px`,
+    left: `${left}px`,
+    top: `${top}px`,
+    background: colors.navy10,
+    borderRadius: '50%',
+    transition: 'all 0.2s',
+  };
+
+  if (altDeg < 0 && altDeg >= -clipDeg) {
+    const horizonInDisc = horizonY - top;
+    const mask = `linear-gradient(to bottom, black ${horizonInDisc}px, transparent ${horizonInDisc}px)`;
+    style.WebkitMaskImage = mask;
+    style.maskImage = mask;
+  }
+
   return (
-    <div
-      id="moon-disc"
-      className="absolute w-16 h-16 rounded-full transition-all duration-200"
-      style={{ top: `${top}px`, left: '50%', transform: 'translateX(-50%)', background: colors.navy10 }}
-    >
+    <div id="moon-disc" style={style}>
       <div
         className="w-full h-full rounded-full"
         style={{ background: gradient }}
@@ -30,3 +62,4 @@ const MoonDisc: React.FC<Props> = ({ visible, phase, altitude }) => {
 };
 
 export default MoonDisc;
+

--- a/src/components/NowPanel.tsx
+++ b/src/components/NowPanel.tsx
@@ -2,27 +2,201 @@ import React from 'react';
 import { DateTime } from 'luxon';
 import { colors } from '../constants/colors';
 import MoonDisc from './MoonDisc';
-import { getMoon } from '../lib/astro';
+import { getMoon, toCompass } from '../lib/astro';
 
 interface Props {
   date: string;
   minute: number;
 }
 
+const clipDeg = 0.6;
+const sampleStep = 5; // minutes
+
+function hexToHsl(hex: string) {
+  let r = 0, g = 0, b = 0;
+  if (hex.length === 4) {
+    r = parseInt(hex[1] + hex[1], 16);
+    g = parseInt(hex[2] + hex[2], 16);
+    b = parseInt(hex[3] + hex[3], 16);
+  } else if (hex.length === 7) {
+    r = parseInt(hex.slice(1, 3), 16);
+    g = parseInt(hex.slice(3, 5), 16);
+    b = parseInt(hex.slice(5, 7), 16);
+  }
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0, s = 0;
+  const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return { h: h * 360, s: s * 100, l: l * 100 };
+}
+
+function hslToString({ h, s, l }: { h: number; s: number; l: number }) {
+  return `hsl(${h}, ${s}%, ${l}%)`;
+}
+
+function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+
 const NowPanel: React.FC<Props> = ({ date, minute }) => {
-  const jsDate = DateTime.fromISO(date)
-    .startOf('day')
-    .plus({ minutes: minute })
-    .toJSDate();
-  const { position, illumination } = getMoon(jsDate, 0, 0);
-  const visible = position.altitude > 0;
+  const canvasRef = React.useRef<HTMLDivElement>(null);
+  const [dim, setDim] = React.useState({ w: 0, h: 0 });
+
+  React.useLayoutEffect(() => {
+    if (canvasRef.current) {
+      setDim({ w: canvasRef.current.clientWidth, h: canvasRef.current.clientHeight });
+    }
+  }, []);
+
+  const dayStart = React.useMemo(() => DateTime.fromISO(date).startOf('day'), [date]);
+
+  const samples = React.useMemo(() => {
+    const arr: { t: number; alt: number; az: number }[] = [];
+    for (let t = 0; t < 1440; t += sampleStep) {
+      const jsDate = dayStart.plus({ minutes: t }).toJSDate();
+      const { position } = getMoon(jsDate, 0, 0);
+      arr.push({ t, alt: (position.altitude * 180) / Math.PI, az: (position.azimuth * 180) / Math.PI });
+    }
+    return arr;
+  }, [dayStart]);
+
+  let tRise = 0;
+  let tSet = 1440;
+  let tPeak = 0;
+  let maxAlt = -90;
+
+  samples.forEach((s, i) => {
+    if (s.alt > maxAlt) {
+      maxAlt = s.alt;
+      tPeak = s.t;
+    }
+    if (i > 0) {
+      const prev = samples[i - 1];
+      if (prev.alt < 0 && s.alt >= 0) tRise = s.t;
+      if (prev.alt >= 0 && s.alt < 0 && tSet === 1440) tSet = prev.t;
+    }
+  });
+
+  const sampleMap = new Map(samples.map((s) => [s.t, s]));
+  const azRise = sampleMap.get(tRise)?.az ?? 0;
+  const azSet = sampleMap.get(tSet)?.az ?? 0;
+  const azPeak = sampleMap.get(tPeak)?.az ?? 0;
+
+  const Wmax = dim.w * 0.9;
+  const Wmin = dim.w * 0.3;
+  const visibleSpan = tSet - tRise;
+  const L = Math.min(Wmax, Math.max(Wmin, (visibleSpan / 1440) * Wmax));
+  const Cx = dim.w / 2;
+
+  const mapAltToY = (alt: number) => {
+    const t = Math.min(Math.max(alt / maxAlt, -clipDeg / maxAlt), 1);
+    return dim.h - t * dim.h;
+  };
+
+  const xAt = (t: number) => Cx + ((t - tPeak) / (tSet - tRise)) * L;
+  const horizonY = mapAltToY(0);
+
+  const pathData = React.useMemo(() => {
+    const pts = samples
+      .filter((s) => s.t >= tRise && s.t <= tSet)
+      .map((s) => `${xAt(s.t)},${mapAltToY(s.alt)}`);
+    return pts.length ? `M ${pts.join(' L ')}` : '';
+  }, [samples, tRise, tSet, dim.w, dim.h]);
+
+  const jsNow = dayStart.plus({ minutes: minute }).toJSDate();
+  const { position, illumination } = getMoon(jsNow, 0, 0);
+  const altDeg = (position.altitude * 180) / Math.PI;
+  const visible = altDeg >= -clipDeg;
+  const x = xAt(minute);
+  const y = mapAltToY(altDeg);
+
+  const scale = 1 - 0.15 * Math.min(Math.max(altDeg / maxAlt, 0), 1);
+  const baseDiameter = 64;
+  const diameter = Math.max(0.05 * Math.min(dim.w, dim.h), baseDiameter * scale);
+
+  const tAlt = Math.min(Math.max(altDeg / maxAlt, 0), 1);
+  const hslYellow = hexToHsl(colors.moonYellow);
+  const hslIvory = hexToHsl(colors.moonIvory);
+  const hslSnow = hexToHsl(colors.moonSnow);
+  let colorHsl;
+  if (tAlt < 0.5) {
+    const tt = tAlt / 0.5;
+    colorHsl = {
+      h: lerp(hslYellow.h, hslIvory.h, tt),
+      s: lerp(hslYellow.s, hslIvory.s, tt),
+      l: lerp(hslYellow.l, hslIvory.l, tt),
+    };
+  } else {
+    const tt = (tAlt - 0.5) / 0.5;
+    colorHsl = {
+      h: lerp(hslIvory.h, hslSnow.h, tt),
+      s: lerp(hslIvory.s, hslSnow.s, tt),
+      l: lerp(hslIvory.l, hslSnow.l, tt),
+    };
+  }
+  const moonColor = hslToString(colorHsl);
+
   return (
     <div id="now-panel" className="flex flex-col items-center space-y-2">
-      <div id="moon-canvas" className="relative w-full h-48 overflow-hidden">
-        <MoonDisc visible={visible} phase={illumination.phase} altitude={position.altitude} />
+      <div
+        id="moon-canvas"
+        ref={canvasRef}
+        className="relative w-full h-48 overflow-hidden"
+      >
+        <svg className="absolute inset-0 w-full h-full" fill="none">
+          <path d={pathData} stroke={colors.gridLine} strokeWidth={1} />
+        </svg>
+        <MoonDisc
+          visible={visible}
+          phase={illumination.phase}
+          x={x}
+          y={y}
+          diameter={diameter}
+          color={moonColor}
+          altDeg={altDeg}
+          horizonY={horizonY}
+          clipDeg={clipDeg}
+        />
+        <div
+          className="absolute text-xs"
+          style={{ left: `${xAt(tRise)}px`, top: `${horizonY + 4}px`, transform: 'translateX(-50%)' }}
+        >
+          {toCompass(azRise)}
+        </div>
+        <div
+          className="absolute text-xs"
+          style={{ left: `${xAt(tSet)}px`, top: `${horizonY + 4}px`, transform: 'translateX(-50%)' }}
+        >
+          {toCompass(azSet)}
+        </div>
+        <div
+          className="absolute text-xs"
+          style={{ left: `${xAt(tPeak)}px`, top: `${mapAltToY(maxAlt) - 16}px`, transform: 'translateX(-50%)' }}
+        >
+          {toCompass(azPeak)}
+        </div>
       </div>
       <div id="moon-info" style={{ color: colors.textMuted }}>
-        Altitude: {position.altitude.toFixed(2)} rad | Phase: {(illumination.phase * 100).toFixed(1)}%
+        Altitude: {altDeg.toFixed(2)}° | Phase: {(illumination.phase * 100).toFixed(1)}%
       </div>
     </div>
   );

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,5 +1,8 @@
 export const colors = {
   ivory: '#FFFFF0',
+  moonYellow: '#F6D365',
+  moonIvory: '#FFFDF3',
+  moonSnow: '#FFFAFA',
   navy00: '#04050f',
   navy10: '#0B1020',
   psychedelicPink: '#f6a6c1',

--- a/src/lib/astro.ts
+++ b/src/lib/astro.ts
@@ -14,3 +14,25 @@ export function getMoonTimes(date: Date, lat: number, lon: number) {
 export function minutesSinceMidnight(date: DateTime) {
   return date.hour * 60 + date.minute;
 }
+
+export function toCompass(azDeg: number) {
+  const dirs = [
+    'N',
+    'NNE',
+    'NE',
+    'ENE',
+    'E',
+    'ESE',
+    'SE',
+    'SSE',
+    'S',
+    'SSW',
+    'SW',
+    'WSW',
+    'W',
+    'WNW',
+    'NW',
+    'NNW',
+  ];
+  return dirs[Math.round(((azDeg % 360) + 360) % 360 / 22.5) % 16];
+}


### PR DESCRIPTION
## Summary
- Compute daily moon altitudes to derive rise, peak, and set times and map them to a centered arc path.
- Render moving moon disc with altitude-based scaling, color transitions, and horizon clipping.
- Display compass labels at rise, peak, and set using azimuth-to-compass conversion.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bac14ba4b08322a0626fa77667b554