### PR TITLE
Add time picker and timeline carousel

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,29 +1,41 @@
 import React, { useState } from 'react';
 import { DateTime } from 'luxon';
-import Header from './Header';
+import { colors } from '../constants/colors';
 import SkyBackdrop from './SkyBackdrop';
 import NowPanel from './NowPanel';
-// import CycleChart from './CycleChart';
+import TimelineScrollbar from './TimelineScrollbar';
+import DatePickerHotkeys from './DatePickerHotkeys';
 
 const AppShell: React.FC = () => {
-  const now = DateTime.now();
-  const [date, setDate] = useState(now.toISODate());
-  const [minutes, setMinutes] = useState(now.hour * 60 + now.minute);
+  const [dateTime, setDateTime] = useState(DateTime.now());
+  const minute = dateTime.hour * 60 + dateTime.minute;
+  const dateStr = dateTime.toISODate();
 
   return (
-    <div id="app-shell" className="min-h-screen relative overflow-hidden">
-      <SkyBackdrop minute={minutes} />
-      <div className="relative z-10 flex flex-col min-h-screen">
-        <Header
-          date={date}
-          onDateChange={setDate}
-          minute={minutes}
-          onMinuteChange={setMinutes}
-        />
-        <main id="main-content" className="flex-1 p-4 space-y-8">
-          <NowPanel date={date} minute={minutes} />
-          {/* <CycleChart /> */}
-        </main>
+    <div id="app-shell" className="h-screen relative overflow-hidden">
+      <SkyBackdrop minute={minute} />
+      <div className="relative z-10 flex flex-col h-full">
+        <div className="flex-1" />
+        <div
+          id="main-content"
+          className="relative flex items-center justify-center"
+          style={{ height: '50vh' }}
+        >
+          <h1
+            id="app-title"
+            className="absolute top-0 left-0 text-xl font-bold p-4"
+            style={{ color: colors.ivory }}
+          >
+            Moonify
+          </h1>
+          <NowPanel date={dateStr} minute={minute} />
+        </div>
+        <div style={{ height: '10vh' }} className="flex items-center">
+          <TimelineScrollbar dateTime={dateTime} onChange={setDateTime} />
+        </div>
+        <div style={{ height: '10vh' }} className="flex items-center">
+          <DatePickerHotkeys dateTime={dateTime} onChange={setDateTime} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/DatePickerHotkeys.tsx
+++ b/src/components/DatePickerHotkeys.tsx
@@ -4,23 +4,45 @@ import { colors } from '../constants/colors';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 
 interface Props {
-  date: string;
-  onChange: (d: string) => void;
+  dateTime: DateTime;
+  onChange: (d: DateTime) => void;
 }
 
-const DatePickerHotkeys: React.FC<Props> = ({ date, onChange }) => {
+const DatePickerHotkeys: React.FC<Props> = ({ dateTime, onChange }) => {
   useKeyboardShortcuts([
-    { keys: ['t'], handler: () => onChange(DateTime.now().toISODate()) },
-    { keys: ['y'], handler: () => onChange(DateTime.now().plus({ days: 1 }).toISODate()) }
+    { keys: ['t'], handler: () => onChange(DateTime.now()) },
+    { keys: ['y'], handler: () => onChange(DateTime.now().plus({ days: 1 })) }
   ]);
+
+  const dateValue = dateTime.toISODate();
+  const timeValue = dateTime.toFormat('HH:mm:ss');
 
   return (
     <div id="date-picker" className="flex items-center space-x-2">
       <input
         id="date-input"
         type="date"
-        value={date}
-        onChange={e => onChange(e.target.value)}
+        value={dateValue}
+        onChange={e => {
+          const d = DateTime.fromISO(e.target.value);
+          onChange(d.set({
+            hour: dateTime.hour,
+            minute: dateTime.minute,
+            second: dateTime.second,
+          }));
+        }}
+        className="bg-navy00 text-textPrimary rounded px-2 py-1"
+        style={{ background: colors.navy00, color: colors.textPrimary, colorScheme: 'dark' }}
+      />
+      <input
+        id="time-input"
+        type="time"
+        step="1"
+        value={timeValue}
+        onChange={e => {
+          const [h, m, s] = e.target.value.split(':').map(Number);
+          onChange(dateTime.set({ hour: h, minute: m, second: s }));
+        }}
         className="bg-navy00 text-textPrimary rounded px-2 py-1"
         style={{ background: colors.navy00, color: colors.textPrimary, colorScheme: 'dark' }}
       />
@@ -28,13 +50,13 @@ const DatePickerHotkeys: React.FC<Props> = ({ date, onChange }) => {
         id="btn-today"
         className="px-2 py-1 rounded"
         style={{ background: colors.navy00, color: colors.ivory }}
-        onClick={() => onChange(DateTime.now().toISODate())}
+        onClick={() => onChange(DateTime.now())}
       >Today</button>
       <button
         id="btn-tomorrow"
         className="px-2 py-1 rounded"
         style={{ background: colors.navy00, color: colors.ivory }}
-        onClick={() => onChange(DateTime.now().plus({ days: 1 }).toISODate())}
+        onClick={() => onChange(DateTime.now().plus({ days: 1 }))}
       >Tomorrow</button>
     </div>
   );


### PR DESCRIPTION
## Summary
- add HH:mm:ss time picker with hotkeys and two-way binding to timeline
- animate timeline navigation in 3-hour increments and position markers below ruler
- restructure layout to center main content and stack timeline/date controls at bottom

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bacacda8e48322881c71400152a0dc