### PR TITLE
Revamp timeline scrolling and layout

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -15,25 +15,23 @@ const AppShell: React.FC = () => {
     <div id="app-shell" className="h-screen relative overflow-hidden">
       <SkyBackdrop minute={minute} />
       <div className="relative z-10 flex flex-col h-full">
-        <div className="flex-1" />
+        <h1
+          id="app-title"
+          className="absolute top-0 left-0 text-xl font-bold p-4"
+          style={{ color: colors.ivory }}
+        >
+          Moonify
+        </h1>
         <div
           id="main-content"
-          className="relative flex items-center justify-center"
-          style={{ height: '50vh' }}
+          className="relative flex flex-col items-center justify-center flex-1 w-full"
         >
-          <h1
-            id="app-title"
-            className="absolute top-0 left-0 text-xl font-bold p-4"
-            style={{ color: colors.ivory }}
-          >
-            Moonify
-          </h1>
           <NowPanel date={dateStr} minute={minute} />
         </div>
-        <div style={{ height: '10vh' }} className="flex items-center">
+        <div style={{ height: '10vh' }} className="flex items-center justify-center w-full">
           <TimelineScrollbar dateTime={dateTime} onChange={setDateTime} />
         </div>
-        <div style={{ height: '10vh' }} className="flex items-center">
+        <div style={{ height: '10vh' }} className="flex items-center justify-center w-full">
           <DatePickerHotkeys dateTime={dateTime} onChange={setDateTime} />
         </div>
       </div>

--- a/src/components/NowPanel.tsx
+++ b/src/components/NowPanel.tsx
@@ -157,7 +157,7 @@ const NowPanel: React.FC<Props> = ({ date, minute }) => {
   const moonColor = hslToString(colorHsl);
 
   return (
-    <div id="now-panel" className="flex flex-col items-center space-y-2">
+    <div id="now-panel" className="flex flex-col items-center space-y-2 w-3/5">
       <div
         id="moon-canvas"
         ref={canvasRef}

--- a/src/components/TimelineScrollbar.tsx
+++ b/src/components/TimelineScrollbar.tsx
@@ -43,6 +43,15 @@ const TimelineScrollbar: React.FC<Props> = ({ dateTime, onChange }) => {
   const minute = dateTime.hour * 60 + dateTime.minute;
   const date = dateTime.toISODate();
 
+  // scrolling state
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const ignoreScrollRef = React.useRef(false);
+  const scrollRafRef = React.useRef<number>();
+  React.useEffect(() => () => cancelAnimationFrame(scrollRafRef.current), []);
+
+  const contentWidth = 2400; // px
+  const pxPerMinute = contentWidth / 1440;
+
   useKeyboardShortcuts([
     { keys: ['arrowleft'], handler: () => onChange(dateTime.minus({ minutes: 5 })) },
     { keys: ['arrowright'], handler: () => onChange(dateTime.plus({ minutes: 5 })) },
@@ -54,14 +63,9 @@ const TimelineScrollbar: React.FC<Props> = ({ dateTime, onChange }) => {
   const rise = times.rise ? minutesSinceMidnight(DateTime.fromJSDate(times.rise)) : null;
   const set = times.set ? minutesSinceMidnight(DateTime.fromJSDate(times.set)) : null;
 
-  const handleLeft = (minute / 1440) * 100;
-  const riseLeft = rise !== null ? (rise / 1440) * 100 : null;
-  const setLeft = set !== null ? (set / 1440) * 100 : null;
+  const risePx = rise !== null ? rise * pxPerMinute : null;
+  const setPx = set !== null ? set * pxPerMinute : null;
 
-  const highlightWidth =
-    riseLeft !== null && setLeft !== null ? setLeft - riseLeft : null;
-
-  const selectedLabel = format(date, minute);
   const riseLabel = rise !== null ? format(date, rise) : null;
   const setLabel = set !== null ? format(date, set) : null;
 
@@ -80,8 +84,44 @@ const TimelineScrollbar: React.FC<Props> = ({ dateTime, onChange }) => {
     onChange(d);
   };
 
+  // sync scroll position when minute changes
+  React.useEffect(() => {
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+    ignoreScrollRef.current = true;
+    scroller.scrollLeft = minute * pxPerMinute - scroller.clientWidth / 2;
+    ignoreScrollRef.current = false;
+  }, [minute, pxPerMinute]);
+
+  const handleScroll = () => {
+    if (ignoreScrollRef.current) return;
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+    const newMinute = Math.round((scroller.scrollLeft + scroller.clientWidth / 2) / pxPerMinute);
+    cancelAnimationFrame(scrollRafRef.current);
+    scrollRafRef.current = requestAnimationFrame(() => {
+      const d = dateTime.startOf('day').plus({ minutes: newMinute, seconds: dateTime.second });
+      onChange(d);
+    });
+  };
+
+  // build visible ranges
+  const ranges: { left: number; width: number }[] = [];
+  if (rise !== null && set !== null) {
+    if (rise < set) {
+      ranges.push({ left: rise * pxPerMinute, width: (set - rise) * pxPerMinute });
+    } else {
+      ranges.push({ left: 0, width: set * pxPerMinute });
+      ranges.push({ left: rise * pxPerMinute, width: (1440 - rise) * pxPerMinute });
+    }
+  } else if (rise !== null) {
+    ranges.push({ left: rise * pxPerMinute, width: (1440 - rise) * pxPerMinute });
+  } else if (set !== null) {
+    ranges.push({ left: 0, width: set * pxPerMinute });
+  }
+
   return (
-    <div id="timeline" className="flex items-center space-x-2 h-full">
+    <div id="timeline" className="flex items-center space-x-2 h-full w-full" >
       <button
         id="timeline-prev"
         className="px-2 py-1 rounded"
@@ -90,61 +130,54 @@ const TimelineScrollbar: React.FC<Props> = ({ dateTime, onChange }) => {
       >
         &lt;&lt;
       </button>
-      <div className="relative flex-1 h-full">
-        <TimelineRange minute={minute} onChange={handleRange} />
-        <div
-          id="selected-time-label"
-          className="absolute text-xs"
-          style={{ top: 0, left: `${handleLeft}%`, transform: 'translateX(-50%)', color: colors.ivory }}
-        >
-          {selectedLabel}
-        </div>
-        <div id="timeline-ruler" className="absolute left-0 right-0" style={{ top: '40%', height: '30%' }}>
-          {highlightWidth !== null && riseLeft !== null && (
-            <div
-              id="moon-visible-range"
-              className="absolute h-full"
-              style={{
-                left: `${riseLeft}%`,
-                width: `${highlightWidth}%`,
-                background: colors.highlightIvory,
-                opacity: 0.3,
-              }}
-            />
-          )}
-          {Array.from({ length: 25 }).map((_, i) => (
-            <div key={i} className="absolute bottom-0" style={{ left: `${(i / 24) * 100}%` }}>
-              <div className="w-px h-2" style={{ background: colors.gridLine }} />
-              {i < 24 && (
-                <div
-                  className="text-xs"
-                  style={{ color: colors.textMuted, transform: 'translateX(-50%)' }}
-                >
-                  {String(i).padStart(2, '0')}:00
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-        <div id="timeline-markers" className="absolute left-0 right-0" style={{ top: '70%' }}>
-          {riseLeft !== null && riseLabel && (
-            <div
-              id="rise-marker"
-              className="absolute text-xs"
-              style={{ left: `${riseLeft}%`, transform: 'translateX(-50%)', color: colors.ivory }}
-            >
-              ↑ {riseLabel}
-            </div>
-          )}
-          {setLeft !== null && setLabel && (
-            <div
-              id="set-marker"
-              className="absolute text-xs"
-              style={{ left: `${setLeft}%`, transform: 'translateX(-50%)', color: colors.ivory }}
-            >
-              ↓ {setLabel}
-            </div>
-          )}
+      <div ref={scrollRef} onScroll={handleScroll} className="relative flex-1 h-full overflow-x-scroll overflow-y-hidden">
+        <div className="relative h-full" style={{ width: `${contentWidth}px` }}>
+          <TimelineRange minute={minute} onChange={handleRange} />
+          <div id="timeline-ruler" className="absolute left-0" style={{ top: '40%', height: '30%', width: `${contentWidth}px` }}>
+            {ranges.map((r, idx) => (
+              <div
+                key={idx}
+                id="moon-visible-range"
+                className="absolute h-full"
+                style={{ left: `${r.left}px`, width: `${r.width}px`, background: colors.highlightIvory, opacity: 0.3 }}
+              />
+            ))}
+            {Array.from({ length: 25 }).map((_, i) => (
+              <div key={i} className="absolute bottom-0" style={{ left: `${(i / 24) * contentWidth}px` }}>
+                <div className="w-px h-2" style={{ background: colors.gridLine }} />
+                {i < 24 && (
+                  <div
+                    className="text-xs"
+                    style={{ color: colors.textMuted, transform: 'translateX(-50%)' }}
+                  >
+                    {String(i).padStart(2, '0')}:00
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+          <div id="timeline-markers" className="absolute left-0" style={{ top: '70%', width: `${contentWidth}px` }}>
+            {risePx !== null && riseLabel && (
+              <div
+                id="rise-marker"
+                className="absolute flex flex-col items-center"
+                style={{ left: `${risePx}px`, transform: 'translateX(-50%)', color: colors.ivory }}
+              >
+                <div className="text-2xl">↑</div>
+                <div className="text-xs">{riseLabel}</div>
+              </div>
+            )}
+            {setPx !== null && setLabel && (
+              <div
+                id="set-marker"
+                className="absolute flex flex-col items-center"
+                style={{ left: `${setPx}px`, transform: 'translateX(-50%)', color: colors.ivory }}
+              >
+                <div className="text-2xl">↓</div>
+                <div className="text-xs">{setLabel}</div>
+              </div>
+            )}
+          </div>
         </div>
       </div>
       <button


### PR DESCRIPTION
## Summary
- Synchronize timeline ruler with range slider and allow manual scrolling
- Highlight moon visibility across midnight with larger rise/set markers
- Reposition app title and center main content at full width

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bad1a4fcd08322a83559e7308ab516