### PR TITLE
Make timeline responsive and enlarge moon panel

### DIFF
--- a/src/components/NowPanel.tsx
+++ b/src/components/NowPanel.tsx
@@ -157,11 +157,11 @@ const NowPanel: React.FC<Props> = ({ date, minute }) => {
   const moonColor = hslToString(colorHsl);
 
   return (
-    <div id="now-panel" className="flex flex-col items-center space-y-2 w-3/5">
+    <div id="now-panel" className="flex flex-col items-center space-y-2 w-[80vw] h-[50vh]">
       <div
         id="moon-canvas"
         ref={canvasRef}
-        className="relative w-full h-48 overflow-hidden"
+        className="relative w-full h-full overflow-hidden"
       >
         <svg className="absolute inset-0 w-full h-full" fill="none">
           <path d={pathData} stroke={colors.gridLine} strokeWidth={1} />
@@ -178,7 +178,7 @@ const NowPanel: React.FC<Props> = ({ date, minute }) => {
           clipDeg={clipDeg}
         />
       </div>
-      <div id="moon-info" className="relative w-full" style={{ color: colors.textMuted }}>
+      <div id="moon-info" className="relative w-full text-textMuted">
         <div
           className="absolute text-xs"
           style={{ left: `${xAt(tRise)}px`, top: 0, transform: 'translateX(-50%)' }}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -13,3 +13,7 @@ input[type='date'] {
 input[type='date']::-webkit-calendar-picker-indicator {
   filter: invert(1);
 }
+
+#main-content > * {
+  margin: 20px;
+}


### PR DESCRIPTION
## Summary
- make timeline percent-based and responsive
- expand moon view to occupy 80vw by 50vh
- add margins for #main-content children

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68badb0f5ebc8322b9884b9e4df6807d