### PR TITLE
Simplify moon rise and adjust picker styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -28,10 +28,16 @@ const AppShell: React.FC = () => {
         >
           <NowPanel date={dateStr} minute={minute} />
         </div>
-        <div style={{ height: '10vh' }} className="flex items-center justify-center w-full">
+        <div
+          style={{ height: '10vh', background: colors.navy00 }}
+          className="flex items-center justify-center w-full"
+        >
           <TimelineScrollbar dateTime={dateTime} onChange={setDateTime} />
         </div>
-        <div style={{ height: '10vh' }} className="flex items-center justify-center w-full">
+        <div
+          style={{ height: '10vh', background: colors.navy00 }}
+          className="flex items-center justify-center w-full"
+        >
           <DatePickerHotkeys dateTime={dateTime} onChange={setDateTime} />
         </div>
       </div>

--- a/src/components/DatePickerHotkeys.tsx
+++ b/src/components/DatePickerHotkeys.tsx
@@ -31,8 +31,8 @@ const DatePickerHotkeys: React.FC<Props> = ({ dateTime, onChange }) => {
             second: dateTime.second,
           }));
         }}
-        className="bg-navy00 text-textPrimary rounded px-2 py-1"
-        style={{ background: colors.navy00, color: colors.textPrimary, colorScheme: 'dark' }}
+        className="rounded px-2 py-1"
+        style={{ background: colors.navy10, color: colors.textPrimary, colorScheme: 'dark' }}
       />
       <input
         id="time-input"
@@ -43,19 +43,19 @@ const DatePickerHotkeys: React.FC<Props> = ({ dateTime, onChange }) => {
           const [h, m, s] = e.target.value.split(':').map(Number);
           onChange(dateTime.set({ hour: h, minute: m, second: s }));
         }}
-        className="bg-navy00 text-textPrimary rounded px-2 py-1"
-        style={{ background: colors.navy00, color: colors.textPrimary, colorScheme: 'dark' }}
+        className="rounded px-2 py-1"
+        style={{ background: colors.navy10, color: colors.textPrimary, colorScheme: 'dark' }}
       />
       <button
         id="btn-today"
         className="px-2 py-1 rounded"
-        style={{ background: colors.navy00, color: colors.ivory }}
+        style={{ background: colors.navy10, color: colors.ivory }}
         onClick={() => onChange(DateTime.now())}
       >Today</button>
       <button
         id="btn-tomorrow"
         className="px-2 py-1 rounded"
-        style={{ background: colors.navy00, color: colors.ivory }}
+        style={{ background: colors.navy10, color: colors.ivory }}
         onClick={() => onChange(DateTime.now().plus({ days: 1 }))}
       >Tomorrow</button>
     </div>


### PR DESCRIPTION
## Summary
- Replace sky arc with simple vertical moon movement and dynamic coloring by altitude
- Restyle date/time inputs and controls with lighter navy backgrounds
- Give lower sections a consistent navy backdrop and ignore node_modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bb25f21b5883229201194ba144a042